### PR TITLE
Workaround to clear value on setFilter for LookupField

### DIFF
--- a/modules/web/src/main/java/com/haulmont/masquerade/components/impl/LookupFieldImpl.java
+++ b/modules/web/src/main/java/com/haulmont/masquerade/components/impl/LookupFieldImpl.java
@@ -19,6 +19,7 @@ package com.haulmont.masquerade.components.impl;
 import com.codeborne.selenide.SelenideElement;
 import com.haulmont.masquerade.components.LookupField;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 
 import static com.codeborne.selenide.Condition.*;
 import static com.codeborne.selenide.Selectors.byClassName;
@@ -73,7 +74,8 @@ public class LookupFieldImpl extends AbstractInputComponent<LookupField> impleme
                 .shouldBe(enabled)
                 .click();
 
-        inputImpl.clear();
+        // being used workaround since clear doesn't work for autocomplete fields
+        inputImpl.sendKeys(Keys.chord(Keys.CONTROL, "a"), Keys.DELETE);
 
         if (!isNullOrEmpty(filter)) {
             // todo may be replace with javascript set to speed up this call


### PR DESCRIPTION
Hi,

Looks like `clear()` doesn't work for LookupField so there is not possible to use method `setFilter()` when the field already has a value.

I've added workaround with Ctrl + A and Delete before sending keys to input.